### PR TITLE
Remove bundle arg from shard factory interface.

### DIFF
--- a/app/src/main/java/me/tatarka/shard/sample/LeakLifecycleWatcher.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/LeakLifecycleWatcher.kt
@@ -28,8 +28,8 @@ class LeakLifecycleWatcher(private val shard: Shard) : LifecycleObserver {
         }
 
         fun wrap(factory: Shard.Factory): Shard.Factory = object : Shard.Factory {
-            override fun <T : Shard> newInstance(name: String, args: Bundle): T =
-                attach(factory.newInstance(name, args))
+            override fun <T : Shard> newInstance(name: String): T =
+                attach(factory.newInstance(name))
         }
     }
 }

--- a/app/src/main/java/me/tatarka/shard/sample/dagger/DaggerShardFactory.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/dagger/DaggerShardFactory.kt
@@ -1,10 +1,5 @@
 package me.tatarka.shard.sample.dagger
 
-import android.os.Bundle
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
-import com.squareup.leakcanary.LeakCanary
 import me.tatarka.shard.app.Shard
 import javax.inject.Inject
 import javax.inject.Provider
@@ -17,6 +12,6 @@ class DaggerShardFactory @Inject constructor(
 
     private val shardMap = shardMap.mapKeys { it.key.name }
 
-    override fun <T : Shard> newInstance(name: String, args: Bundle): T =
+    override fun <T : Shard> newInstance(name: String): T =
         shardMap.getValue(name).get() as T
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'signing'
 apply plugin: 'digital.wup.android-maven-publish'
 
 group = 'me.tatarka.shard'
-version = '1.0.0-alpha05'
+version = '1.0.0-alpha06-SNAPSHOT'
 
 task sourcesJar(type: Jar) {
     classifier = 'sources'

--- a/shard-ktx/src/main/java/me/tatarka/shard/app/Shard.kt
+++ b/shard-ktx/src/main/java/me/tatarka/shard/app/Shard.kt
@@ -1,6 +1,3 @@
 package me.tatarka.shard.app
 
-import android.os.Bundle
-
-inline fun <reified T : Shard> Shard.Factory.newInstance(args: Bundle = Bundle.EMPTY) =
-        newInstance<T>(T::class.java.name, args)
+inline fun <reified T : Shard> Shard.Factory.newInstance() = newInstance<T>(T::class.java.name)

--- a/shard-nav/src/main/java/me/tatarka/shard/nav/ShardNavigator.java
+++ b/shard-nav/src/main/java/me/tatarka/shard/nav/ShardNavigator.java
@@ -47,7 +47,7 @@ public class ShardNavigator extends OptimizingNavigator<ShardNavigator.Destinati
     @NonNull
     @Override
     protected Page createPage(Destination destination, @Nullable Bundle args, @Nullable NavOptions navOptions, @Nullable Navigator.Extras navExtras) {
-        Shard shard = destination.shardFactory.newInstance(destination.getName(), args != null ? args : Bundle.EMPTY);
+        Shard shard = destination.shardFactory.newInstance(destination.getName());
         shard.setArgs(args);
         return new Page(factory, shard, navOptions, (Extras) navExtras);
     }
@@ -178,7 +178,7 @@ public class ShardNavigator extends OptimizingNavigator<ShardNavigator.Destinati
         }
 
         Page restore(ShardManager fm, Shard.Factory factory) {
-            Shard shard = factory.newInstance(name, state.getArgs());
+            Shard shard = factory.newInstance(name);
             fm.restoreState(shard, state);
             return new Page(factory, shard, this);
         }

--- a/shard/src/main/java/me/tatarka/shard/app/Shard.java
+++ b/shard/src/main/java/me/tatarka/shard/app/Shard.java
@@ -404,14 +404,6 @@ public class Shard implements ShardOwner {
         Bundle savedState;
         SparseArray viewState;
 
-        /**
-         * Returns the arguments for this shard, you can only read these, you cannot modify them.
-         */
-        @NonNull
-        public Bundle getArgs() {
-            return args != null ? args : Bundle.EMPTY;
-        }
-
         State(int viewModelId, @Nullable Bundle args) {
             this.viewModelId = viewModelId;
             this.args = args;
@@ -456,14 +448,12 @@ public class Shard implements ShardOwner {
      */
     public interface Factory {
         /**
-         * Constructs a new instance of the shard with the given arguments.
+         * Constructs a new instance of the shard.
          *
          * @param name The shard's class name.
-         * @param args The args for the shard. You may pass {@link Bundle#EMPTY} if there are
-         *             none.
          */
         @NonNull
-        <T extends Shard> T newInstance(@NonNull String name, @NonNull Bundle args);
+        <T extends Shard> T newInstance(@NonNull String name);
     }
 
     /**
@@ -482,7 +472,7 @@ public class Shard implements ShardOwner {
         @NonNull
         @Override
         @SuppressWarnings("unchecked")
-        public <T extends Shard> T newInstance(@NonNull String name, @NonNull Bundle args) {
+        public <T extends Shard> T newInstance(@NonNull String name) {
             try {
                 return (T) Class.forName(name).getConstructor().newInstance();
             } catch (ClassNotFoundException e) {

--- a/shard/src/main/java/me/tatarka/shard/app/ShardDialogHost.java
+++ b/shard/src/main/java/me/tatarka/shard/app/ShardDialogHost.java
@@ -135,7 +135,7 @@ public class ShardDialogHost {
             for (int i = 0, size = states.size(); i < size; i++) {
                 String name = states.keyAt(i);
                 Shard.State shardState = states.valueAt(i);
-                BaseDialogShard shard = getShardFactory().newInstance(name, shardState.getArgs());
+                BaseDialogShard shard = getShardFactory().newInstance(name);
                 fm.restoreState(shard, shardState);
                 dialogShards.add(shard);
                 if (owner.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.CREATED)) {

--- a/shard/src/main/java/me/tatarka/shard/wiget/ShardHost.java
+++ b/shard/src/main/java/me/tatarka/shard/wiget/ShardHost.java
@@ -63,7 +63,7 @@ public class ShardHost extends FrameLayout {
         }
         if (!isInEditMode()) {
             if (initialName != null && !ShardManager.isRestoringState(owner)) {
-                shard = getShardFactory().newInstance(initialName, Bundle.EMPTY);
+                shard = getShardFactory().newInstance(initialName);
                 fm.add(shard, this);
             }
         } else {
@@ -125,7 +125,7 @@ public class ShardHost extends FrameLayout {
         String name = savedState.name;
         Shard.State shardState = savedState.shardState;
         if (name != null && shardState != null) {
-            shard = getShardFactory().newInstance(name, shardState.getArgs());
+            shard = getShardFactory().newInstance(name);
             fm.restoreState(shard, shardState);
             fm.add(shard, this);
         }


### PR DESCRIPTION
It's confusing since the factory doesn't call setArgs(), this was
recently removed from fragments.

https://android-review.googlesource.com/c/platform/frameworks/support/+/932496/