### PR TITLE
Remove @ContentView support, implement tools:layout for layout preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ def shard_version = '1.0.0-alpha06-SNAPSHOT'
 
 Creating a shard is as simple as
 ```kotlin
-@ContentView(R.layout.my_shard)
 class MyShard: Shard() {
     const val REQUEST_CODE = 1
 
     override fun onCreate() {
+        setContentView(R.layout.my_shard)
         // find a view
         val name: TextView = requireViewById(R.id.name)
         // get a ViewModel
@@ -74,7 +74,8 @@ class MyShard: Shard() {
     android:id="@+id/host"
     android:name="com.example.MyShard"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    tools:layout="@layout/my_shard" />
 ```
 
 ## Full Documentation

--- a/app/src/main/java/me/tatarka/shard/sample/DialogHostShard.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/DialogHostShard.kt
@@ -6,9 +6,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.view.View
 import android.widget.Button
-import androidx.annotation.ContentView
 import me.tatarka.shard.app.Shard
-import me.tatarka.shard.app.ShardDialogHost
 import me.tatarka.shard.app.newInstance
 import me.tatarka.shard.app.showDialog
 import javax.inject.Inject
@@ -16,10 +14,10 @@ import javax.inject.Inject
 const val REQUEST_CODE_ACTIVITY = 1
 const val REQUEST_CODE_PERMISSION = 2
 
-@ContentView(R.layout.dialogs)
 class DialogHostShard @Inject constructor() : Shard() {
 
     override fun onCreate() {
+        setContentView(R.layout.dialogs)
         activityCallbacks.addOnActivityResultCallback(REQUEST_CODE_ACTIVITY) { resultCode, _ ->
             requireViewById<Button>(R.id.start_activity_for_result).text =
                     "Result: ${if (resultCode == Activity.RESULT_OK) "Ok" else "Cancel"}"

--- a/app/src/main/java/me/tatarka/shard/sample/MyShard.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/MyShard.kt
@@ -14,7 +14,6 @@ import javax.inject.Inject
 
 private const val KEY_NUMBER = "number"
 
-@ContentView(R.layout.shard)
 class MyShard @Inject constructor(
         private val lifecycleLogger: LifecycleLogger,
         private val stateLogger: InstanceStateLogger,
@@ -26,6 +25,7 @@ class MyShard @Inject constructor(
     }
 
     override fun onCreate() {
+        setContentView(R.layout.shard)
         activityCallbacks.addOnMultiWindowModeChangedCallback(callbacksLogger)
         activityCallbacks.addOnPictureInPictureModeChangedCallback(callbacksLogger)
         componentCallbacks.addOnConfigurationChangedListener(callbacksLogger)

--- a/app/src/main/java/me/tatarka/shard/sample/NavigationShard.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/NavigationShard.kt
@@ -1,7 +1,6 @@
 package me.tatarka.shard.sample
 
 import android.view.View
-import androidx.annotation.ContentView
 import androidx.appcompat.widget.Toolbar
 import androidx.navigation.NavController
 import androidx.navigation.Navigation.findNavController
@@ -10,12 +9,12 @@ import me.tatarka.shard.app.Shard
 import me.tatarka.shard.nav.ShardNavigator
 import javax.inject.Inject
 
-@ContentView(R.layout.navigation)
 class NavigationShard @Inject constructor() : Shard() {
 
     lateinit var controller: NavController
 
     override fun onCreate() {
+        setContentView(R.layout.navigation)
         controller = findNavController(requireViewById(R.id.nav))
         requireViewById<Toolbar>(R.id.toolbar).setupWithNavController(controller)
         requireViewById<View>(R.id.root).setOnClickListener { controller.navigate(R.id.root) }

--- a/app/src/main/java/me/tatarka/shard/sample/ShardSquareLeft.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/ShardSquareLeft.kt
@@ -1,13 +1,12 @@
 package me.tatarka.shard.sample
 
-import androidx.annotation.ContentView
 import androidx.core.view.ViewCompat
 import me.tatarka.shard.app.Shard
 import javax.inject.Inject
 
-@ContentView(R.layout.shard_square_left)
 class ShardSquareLeft @Inject constructor() : Shard() {
     override fun onCreate() {
+        setContentView(R.layout.shard_square_left)
         ViewCompat.setTransitionName(requireViewById(R.id.square_left), "square")
     }
 }

--- a/app/src/main/java/me/tatarka/shard/sample/ShardSquareMiddle.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/ShardSquareMiddle.kt
@@ -1,13 +1,12 @@
 package me.tatarka.shard.sample
 
-import androidx.annotation.ContentView
 import androidx.core.view.ViewCompat
 import me.tatarka.shard.app.Shard
 import javax.inject.Inject
 
-@ContentView(R.layout.shard_square_middle)
 class ShardSquareMiddle @Inject constructor() : Shard() {
     override fun onCreate() {
+        setContentView(R.layout.shard_square_middle)
         ViewCompat.setTransitionName(requireViewById(R.id.square_middle), "square")
     }
 }

--- a/app/src/main/java/me/tatarka/shard/sample/ShardSquareRight.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/ShardSquareRight.kt
@@ -1,13 +1,12 @@
 package me.tatarka.shard.sample
 
-import androidx.annotation.ContentView
 import androidx.core.view.ViewCompat
 import me.tatarka.shard.app.Shard
 import javax.inject.Inject
 
-@ContentView(R.layout.shard_square_right)
 class ShardSquareRight @Inject constructor() : Shard() {
     override fun onCreate() {
+        setContentView(R.layout.shard_square_right)
         ViewCompat.setTransitionName(requireViewById(R.id.square_right), "square")
     }
 }

--- a/app/src/main/java/me/tatarka/shard/sample/SimpleDialogShard.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/SimpleDialogShard.kt
@@ -7,7 +7,6 @@ import javax.inject.Inject
 
 private const val KEY_NUMBER = "number"
 
-@ContentView(R.layout.dialog)
 class SimpleDialogShard @Inject constructor() : DialogShard() {
 
     fun withNumber(number: Int): SimpleDialogShard = apply {
@@ -15,6 +14,7 @@ class SimpleDialogShard @Inject constructor() : DialogShard() {
     }
 
     override fun onCreate() {
+        setContentView(R.layout.dialog)
         requireViewById<TextView>(R.id.number).text = args.getInt(KEY_NUMBER).toString()
     }
 }

--- a/app/src/main/java/me/tatarka/shard/sample/SimpleHostShard.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/SimpleHostShard.kt
@@ -8,10 +8,10 @@ import me.tatarka.shard.transition.ShardTransitionCompat
 import me.tatarka.shard.wiget.ShardHost
 import javax.inject.Inject
 
-@ContentView(R.layout.simple_host)
 class SimpleHostShard @Inject constructor() : Shard() {
 
     override fun onCreate() {
+        setContentView(R.layout.simple_host)
         val host: ShardHost = requireViewById(R.id.host)
         host.defaultTransition =
                 ShardTransitionCompat.fromTransitionRes(context, R.transition.square_transition)

--- a/app/src/main/java/me/tatarka/shard/sample/ViewPagerShard.kt
+++ b/app/src/main/java/me/tatarka/shard/sample/ViewPagerShard.kt
@@ -1,16 +1,15 @@
 package me.tatarka.shard.sample
 
-import androidx.annotation.ContentView
 import androidx.viewpager.widget.ViewPager
 import me.tatarka.shard.app.Shard
 import me.tatarka.shard.app.newInstance
 import me.tatarka.shard.pager.ShardPagerAdapter
 import javax.inject.Inject
 
-@ContentView(R.layout.view_pager)
 class ViewPagerShard @Inject constructor() : Shard() {
 
     override fun onCreate() {
+        setContentView(R.layout.view_pager)
         val pager: ViewPager = requireViewById(R.id.pager)
         pager.adapter = object : ShardPagerAdapter(this) {
             override fun getItem(position: Int): Shard {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,7 +13,8 @@
         android:layout_height="0dp"
         android:layout_weight="1"
         app:startPage="@+id/simple_host"
-        app:transition="@transition/page_transition" />
+        app:transition="@transition/page_transition"
+        tools:layout="@layout/simple_host" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_nav"

--- a/app/src/main/res/layout/navigation.xml
+++ b/app/src/main/res/layout/navigation.xml
@@ -32,7 +32,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:navGraph="@navigation/nav_graph" />
+            app:navGraph="@navigation/nav_graph"
+            tools:layout="@layout/shard" />
 
         <Button
             android:id="@+id/root"

--- a/app/src/main/res/layout/simple_host.xml
+++ b/app/src/main/res/layout/simple_host.xml
@@ -2,7 +2,8 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"
@@ -32,7 +33,8 @@
             app:layout_constraintBottom_toTopOf="@+id/one"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout="@layout/shard"/>
 
         <Button
             android:id="@+id/one"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0-alpha07'
+        classpath 'com.android.tools.build:gradle:3.5.0-alpha08'
         classpath 'digital.wup:android-maven-publish:3.6.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }

--- a/docs/implementing-shards.md
+++ b/docs/implementing-shards.md
@@ -14,15 +14,13 @@ class MyShard: Shard() {
 
 ## Views
 
-The easiest way to set the contents of a shard is by annotating the class with `@ContentView`.
-Alternatively, you can use `setContentView(layout)` or `setContentView(view)` if you need something
-dynamic. You can find views with `findVieById()` or `requireViewById()`. You can access the root
-view with `getView()`.
+You can use `setContentView(layout)` or `setContentView(view)` to set the shard's view. You can find 
+views with `findViewById()` or `requireViewById()`. You can access the root view with `getView()`.
 
 ```kotlin
-@ContentView(R.layout.my_shard)
 class MyShard: Shard() {
     override fun onCreate() {
+        setContentView(R.layout.my_shard)
         val name: TextView = requireViewById(R.id.name)
         name.text = "My Name"
     }

--- a/docs/migrating-from-fragments.md
+++ b/docs/migrating-from-fragments.md
@@ -19,9 +19,9 @@ class MyFragment : Fragment() {
 
 *Shard*
 ```kotlin
-@ContentView(R.layout.my_shard)
 class MyShard : Shard() {
     override fun onCreate() {
+        setContentView(R.layout.my_shard)
         requireViewById<TextView>(R.id.name).text = "My Name"
     }
 }
@@ -97,8 +97,11 @@ button.setOnClickListener {
 
 *Shard*
 ```kotlin
-@ContentView(R.layout.dialog)
 class MyDialogShard : DialogShard() {
+    override fun onCreate() {
+        setContentView(R.layout.dialog)
+    }
+
     override fun onCreateDialog(context: Context): Dialog {
         return Dialog(context)
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 09 22:21:31 EST 2019
+#Mon Mar 25 19:42:33 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-all.zip

--- a/shard-nav/src/main/java/me/tatarka/shard/nav/ShardNavHost.java
+++ b/shard-nav/src/main/java/me/tatarka/shard/nav/ShardNavHost.java
@@ -44,6 +44,12 @@ public class ShardNavHost extends FrameLayout implements NavHost {
         if (attrs != null) {
             TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.ShardNavHost);
             graphId = a.getResourceId(R.styleable.ShardNavHost_navGraph, 0);
+            if (isInEditMode()) {
+                int layout = a.getResourceId(R.styleable.ShardNavHost_layout, 0);
+                if (layout != 0) {
+                    inflate(context, layout, this);
+                }
+            }
             a.recycle();
             Navigation.setViewNavController(this, navController);
             ShardNavigator shardNavigator = new ShardNavigator(this);
@@ -55,24 +61,6 @@ public class ShardNavHost extends FrameLayout implements NavHost {
             }
             NavCallbacks navCallbacks = new NavCallbacks(owner, navController);
             addOnAttachStateChangeListener(navCallbacks);
-        } else {
-            // If the shard is annotated we can show the layout in the preview.
-           if (graphId != 0)  {
-               NavGraph graph = new NavInflater(context, navController.getNavigatorProvider()).inflate(graphId);
-               NavDestination destination = graph.findNode(graph.getStartDestination());
-               if (destination instanceof ShardNavigator.Destination) {
-                   String name = ((ShardNavigator.Destination) destination).getName();
-                   try {
-                       Class<?> shardClass = Class.forName(name);
-                       ContentView contentView = shardClass.getAnnotation(ContentView.class);
-                       if (contentView != null) {
-                           inflate(context, contentView.value(), this);
-                       }
-                   } catch (ClassNotFoundException e) {
-                       throw new RuntimeException(e);
-                   }
-               }
-           }
         }
     }
 

--- a/shard-nav/src/main/res/values/attrs.xml
+++ b/shard-nav/src/main/res/values/attrs.xml
@@ -5,5 +5,6 @@
     </declare-styleable>
     <declare-styleable name="ShardNavHost">
         <attr name="navGraph" format="reference" />
+        <attr name="layout" />
     </declare-styleable>
 </resources>

--- a/shard/src/main/java/me/tatarka/shard/app/Shard.java
+++ b/shard/src/main/java/me/tatarka/shard/app/Shard.java
@@ -91,10 +91,6 @@ public class Shard implements ShardOwner {
         stateRegistryController.performRestore(state != null ? state.savedState : null);
         activityCallbackDispatcher = new NestedActivityCallbacksDispatcher((BaseActivityCallbacksDispatcher) owner.getActivityCallbacks(), this);
         componentCallbacksDispatcher = new ComponentCallbacksDispatcher(this);
-        ContentView contentView = getClass().getAnnotation(ContentView.class);
-        if (contentView != null) {
-            setContentView(contentView.value());
-        }
         onCreate();
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
 

--- a/shard/src/main/java/me/tatarka/shard/wiget/ShardHost.java
+++ b/shard/src/main/java/me/tatarka/shard/wiget/ShardHost.java
@@ -59,25 +59,18 @@ public class ShardHost extends FrameLayout {
                     defaultTransition = ShardTransition.fromAnimRes(context, enterAnimId, exitAnimId);
                 }
             }
+            if (isInEditMode()) {
+                int layout = a.getResourceId(R.styleable.ShardHost_layout, 0);
+                if (layout != 0) {
+                    inflate(context, layout, this);
+                }
+            }
             a.recycle();
         }
         if (!isInEditMode()) {
             if (initialName != null && !ShardManager.isRestoringState(owner)) {
                 shard = getShardFactory().newInstance(initialName);
                 fm.add(shard, this);
-            }
-        } else {
-            // If the shard is annotated we can show the layout in the preview.
-            if (initialName != null) {
-                try {
-                    Class<?> shardClass = Class.forName(initialName);
-                    ContentView contentView = shardClass.getAnnotation(ContentView.class);
-                    if (contentView != null) {
-                        inflate(context, contentView.value(), this);
-                    }
-                } catch (ClassNotFoundException e) {
-                    throw new RuntimeException(e);
-                }
             }
         }
     }

--- a/shard/src/main/java/me/tatarka/shard/wiget/ShardPageHost.java
+++ b/shard/src/main/java/me/tatarka/shard/wiget/ShardPageHost.java
@@ -61,6 +61,12 @@ public class ShardPageHost extends FrameLayout {
                     defaultTransition = ShardTransition.fromAnimRes(context, enterAnimId, exitAnimId);
                 }
             }
+            if (isInEditMode()) {
+                int layout = a.getResourceId(R.styleable.ShardPageHost_layout, 0);
+                if (layout != 0) {
+                    inflate(context, layout, this);
+                }
+            }
             a.recycle();
         }
         if (!isInEditMode()) {

--- a/shard/src/main/res/values/attrs.xml
+++ b/shard/src/main/res/values/attrs.xml
@@ -9,11 +9,13 @@
         <attr name="enterAnim" />
         <attr name="exitAnim" />
         <attr name="transition" />
+        <attr name="layout" />
     </declare-styleable>
     <declare-styleable name="ShardPageHost">
         <attr name="startPage" format="reference" />
         <attr name="enterAnim" />
         <attr name="exitAnim" />
         <attr name="transition" />
+        <attr name="layout" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
It didn't support library projects, so how it works is going to change
https://issuetracker.google.com/issues/128352521. Since it's not clear
what tooling benefit the constructor call has, going to just remove all
support for now. You can use tools:layout="@layout/my_layout" for the
layout preview as an alternative.